### PR TITLE
25: rename ProviderConfig/StoreConfig group to akash.overlock.network

### DIFF
--- a/apis/v1alpha1/groupversion_info.go
+++ b/apis/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the core resources of the Akash provider.
 // +kubebuilder:object:generate=true
-// +groupName=akash.web7.md
+// +groupName=akash.overlock.network
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "akash.web7.md"
+	Group   = "akash.overlock.network"
 	Version = "v1alpha1"
 )
 

--- a/examples/provider/config.yaml
+++ b/examples/provider/config.yaml
@@ -8,7 +8,7 @@ data:
 
 ---
 
-apiVersion: akash.web7.md/v1alpha1
+apiVersion: akash.overlock.network/v1alpha1
 kind: ProviderConfig
 metadata:
   name: example

--- a/package/crds/akash.overlock.network_providerconfigs.yaml
+++ b/package/crds/akash.overlock.network_providerconfigs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.0
-  name: providerconfigs.akash.web7.md
+  name: providerconfigs.akash.overlock.network
 spec:
-  group: akash.web7.md
+  group: akash.overlock.network
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/package/crds/akash.overlock.network_providerconfigusages.yaml
+++ b/package/crds/akash.overlock.network_providerconfigusages.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.0
-  name: providerconfigusages.akash.web7.md
+  name: providerconfigusages.akash.overlock.network
 spec:
-  group: akash.web7.md
+  group: akash.overlock.network
   names:
     categories:
     - crossplane

--- a/package/crds/akash.overlock.network_storeconfigs.yaml
+++ b/package/crds/akash.overlock.network_storeconfigs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.0
-  name: storeconfigs.akash.web7.md
+  name: storeconfigs.akash.overlock.network
 spec:
-  group: akash.web7.md
+  group: akash.overlock.network
   names:
     categories:
     - crossplane


### PR DESCRIPTION
## Summary
- Rename API group `akash.web7.md` → `akash.overlock.network` for the core provider types (`ProviderConfig`, `ProviderConfigUsage`, `StoreConfig`)
- Update `+groupName` kubebuilder marker and `Group` constant in `apis/v1alpha1/groupversion_info.go`
- Regenerate CRDs (renames `package/crds/akash.web7.md_*.yaml` → `package/crds/akash.overlock.network_*.yaml`)
- Update `examples/provider/config.yaml` apiVersion

Brings the core types in line with the Akash resource group already used for `Deployment`, `SDL`, `ActiveBid`, `BidPolicy`, `Lease`.

## Test plan
- [x] `go build ./...` and `go test ./...`
- [x] Manual: install the provider, apply `examples/provider/config.yaml`, verify ProviderConfig is admitted under the new group and downstream Deployment/Lease/etc. continue to reconcile