### PR TITLE
15: ActiveBid scanner mirrors chain bids as ActiveBid CRs

### DIFF
--- a/internal/controller/activebid/activebid.go
+++ b/internal/controller/activebid/activebid.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -94,12 +95,18 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...))
 
-	return ctrl.NewControllerManagedBy(mgr).
+	if err := ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(resource.DesiredStateChanged()).
 		For(&akashv1alpha1.ActiveBid{}).
-		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter)); err != nil {
+		return err
+	}
+
+	// Producer side of the same module: scan Deployments and create
+	// ActiveBid CRs for each chain bid we observe.
+	return SetupScanner(mgr, o)
 }
 
 // A connector is expected to produce an ExternalClient when its Connect method is called.
@@ -158,9 +165,25 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	fmt.Printf("Observing ActiveBids for deployment reference: %s\n", cr.Spec.ForProvider.DeploymentRef.Name)
 
-	// Resolve the deployment reference to get DSEQ and owner
+	// ActiveBid is observation-only: bids on the Akash chain transition
+	// state autonomously and we never broadcast a delete tx for them.
+	// Once the user requests deletion of the CR there is therefore no
+	// "external resource" to wait on — return ResourceExists=false so
+	// Crossplane clears the managed-resource finalizer immediately.
+	if cr.GetDeletionTimestamp() != nil {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+
+	// Resolve the deployment reference to get DSEQ and owner. If the parent
+	// Deployment is gone (e.g., user deleted it and we're being cascade-
+	// deleted), report ResourceExists=false so the managed reconciler can
+	// proceed to Delete instead of looping on Observe forever.
 	deployment, err := c.getReferencedDeployment(ctx, cr)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			setStatusCondition(cr, xpv1.TypeSynced, corev1.ConditionFalse, xpv1.ReasonReconcileSuccess, "Referenced deployment is gone")
+			return managed.ExternalObservation{ResourceExists: false}, nil
+		}
 		setStatusCondition(cr, xpv1.TypeSynced, corev1.ConditionFalse, xpv1.ReasonReconcileError, fmt.Sprintf("Failed to get deployment: %v", err))
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetDeployment)
 	}
@@ -209,18 +232,22 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			}, nil
 		}
 
-		// Update status with bid information
+		// Update status with bid information (price, ids).
 		c.updateStatusWithBid(cr, bid, dseq)
 		// Set the bidId in status as well
 		cr.Status.AtProvider.BidId = bidId
-		
-		// Transition from pending to received once we successfully fetch the bid
-		if cr.Status.AtProvider.State == "" || cr.Status.AtProvider.State == "pending" {
-			cr.Status.AtProvider.State = "received"
-			// Set receivedAt timestamp
-			if cr.Status.AtProvider.ReceivedAt == 0 {
-				cr.Status.AtProvider.ReceivedAt = metav1.Now().Unix()
-			}
+
+		// Mirror the chain Bid_State directly. The chain values
+		// (open|active|lost|closed) are the source of truth and must
+		// keep refreshing — without this every ActiveBid would freeze
+		// at "received" even after the bid window expires.
+		if bid.State != "" {
+			cr.Status.AtProvider.State = bid.State
+		} else if cr.Status.AtProvider.State == "" {
+			cr.Status.AtProvider.State = "pending"
+		}
+		if cr.Status.AtProvider.ReceivedAt == 0 {
+			cr.Status.AtProvider.ReceivedAt = metav1.Now().Unix()
 		}
 
 		setStatusCondition(cr, xpv1.TypeSynced, corev1.ConditionTrue, xpv1.ReasonReconcileSuccess, "Successfully fetched bid")

--- a/internal/controller/activebid/scanner.go
+++ b/internal/controller/activebid/scanner.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2024 The Akash Provider Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+*/
+
+package activebid
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	kubeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+
+	akashv1alpha1 "github.com/overlock-network/provider-akash/apis/akash/v1alpha1"
+	"github.com/overlock-network/provider-akash/apis/resource/v1alpha1"
+	apisv1alpha1 "github.com/overlock-network/provider-akash/apis/v1alpha1"
+	client "github.com/overlock-network/provider-akash/internal/client"
+)
+
+// bidScanner is a secondary reconciler living inside the activebid module.
+// It watches Deployment CRs and, for each on-chain Deployment, queries the
+// chain for bids and creates one ActiveBid CR per chain bid. The existing
+// per-CR ActiveBid Observe (managed reconciler) then refreshes each
+// ActiveBid's status from chain on every poll.
+//
+// Putting the producer here (rather than inside BidPolicy or the Deployment
+// controller) keeps "one entity → one controller": every aspect of the
+// ActiveBid lifecycle — creation, observation, and status — lives in this
+// package.
+type bidScanner struct {
+	kubeClient kubeclient.Client
+}
+
+// SetupScanner wires the bidScanner reconciler into the manager. Called from
+// activebid.Setup alongside the standard managed-resource controller.
+func SetupScanner(mgr ctrl.Manager, _ controller.Options) error {
+	r := &bidScanner{kubeClient: mgr.GetClient()}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("activebid-scanner").
+		For(&v1alpha1.Deployment{}).
+		Complete(r)
+}
+
+// Reconcile fires for each Deployment event. If the Deployment is on chain
+// (DSEQ + owner populated) we query bids and ensure an ActiveBid CR exists
+// for each one. Errors from the chain query are non-fatal: the reconcile
+// returns nil so controller-runtime requeues on its own schedule.
+func (r *bidScanner) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	dep := &v1alpha1.Deployment{}
+	if err := r.kubeClient.Get(ctx, req.NamespacedName, dep); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	dseq := dep.Status.AtProvider.DeploymentId
+	owner := dep.Status.AtProvider.Owner
+	if dseq == "" || owner == "" {
+		// Not on chain yet; the next Deployment event will retrigger.
+		return reconcile.Result{}, nil
+	}
+
+	akash, err := r.buildAkashClient(ctx, dep)
+	if err != nil {
+		fmt.Printf("activebid-scanner: cannot build Akash client for %s: %v\n", dep.Name, err)
+		return reconcile.Result{}, nil
+	}
+
+	bids, err := akash.GetBids(ctx, dseq, owner)
+	if err != nil {
+		fmt.Printf("activebid-scanner: GetBids %s/%s: %v\n", owner, dseq, err)
+		return reconcile.Result{}, nil
+	}
+
+	for _, b := range bids {
+		bidId := fmt.Sprintf("%s-%s-%s-%s-%s", b.Id.Owner, b.Id.Dseq, b.Id.Gseq, b.Id.Oseq, b.Id.Provider)
+		if err := r.ensureActiveBid(ctx, dep, bidId); err != nil {
+			fmt.Printf("activebid-scanner: ensureActiveBid %s: %v\n", bidId, err)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+// buildAkashClient constructs a chain-talking AkashClient using the
+// Deployment's ProviderConfig. It mirrors the resolution path used by every
+// other managed reconciler in this provider.
+func (r *bidScanner) buildAkashClient(ctx context.Context, dep *v1alpha1.Deployment) (*client.AkashClient, error) {
+	ref := dep.GetProviderConfigReference()
+	if ref == nil {
+		return nil, errors.New("deployment has no providerConfigRef")
+	}
+	pc := &apisv1alpha1.ProviderConfig{}
+	if err := r.kubeClient.Get(ctx, types.NamespacedName{Name: ref.Name}, pc); err != nil {
+		return nil, errors.Wrap(err, "cannot get ProviderConfig")
+	}
+	pcInfo := client.ProviderConfigInfo{
+		Source:              pc.Spec.Credentials.Source,
+		CredentialSelectors: pc.Spec.Credentials.CommonCredentialSelectors,
+		Configuration:       pc.Spec.Configuration,
+	}
+	if pc.Spec.Passphrase != nil {
+		pcInfo.PassphraseSource = &pc.Spec.Passphrase.Source
+		pcInfo.PassphraseSelectors = &pc.Spec.Passphrase.CommonCredentialSelectors
+	}
+	return client.NewFromManagedResource(ctx, r.kubeClient, nil, dep, pcInfo)
+}
+
+// ensureActiveBid creates an ActiveBid CR for the given chain bidId if one
+// doesn't exist. Idempotent — safe to call on every Deployment reconcile.
+func (r *bidScanner) ensureActiveBid(ctx context.Context, dep *v1alpha1.Deployment, bidId string) error {
+	name := scannerActiveBidName(dep.Name, bidId)
+
+	existing := &akashv1alpha1.ActiveBid{}
+	err := r.kubeClient.Get(ctx, kubeclient.ObjectKey{Name: name}, existing)
+	switch {
+	case err == nil:
+		return nil
+	case !apierrors.IsNotFound(err):
+		return err
+	}
+
+	depNs := dep.Namespace
+	truthy := true
+	ab := &akashv1alpha1.ActiveBid{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"akash.overlock.network/deployment": dep.Name,
+				"akash.overlock.network/dseq":       dep.Status.AtProvider.DeploymentId,
+			},
+			// Tying ActiveBids to the Deployment via ownerRef means K8s
+			// garbage-collects them when the Deployment CR is deleted —
+			// no stale ActiveBids referencing a previous DSEQ if the
+			// user re-creates the Deployment under the same name.
+			OwnerReferences: []metav1.OwnerReference{{
+				// APIVersion/Kind aren't populated on typed Get() — fill
+				// them from the resource type so the GC controller can
+				// resolve the owner correctly.
+				APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+				Kind:               v1alpha1.DeploymentKind,
+				Name:               dep.Name,
+				UID:                dep.UID,
+				Controller:         &truthy,
+				BlockOwnerDeletion: &truthy,
+			}},
+		},
+		Spec: akashv1alpha1.ActiveBidSpec{
+			ResourceSpec: xpv1.ResourceSpec{
+				ProviderConfigReference: dep.GetProviderConfigReference(),
+			},
+			ForProvider: akashv1alpha1.ActiveBidParameters{
+				DeploymentRef: akashv1alpha1.DeploymentReference{
+					Name:      dep.Name,
+					Namespace: &depNs,
+				},
+				BidId: bidId,
+			},
+		},
+	}
+	return r.kubeClient.Create(ctx, ab)
+}
+
+// scannerActiveBidName produces a stable DNS-1123 name for an ActiveBid CR.
+// Hash-based to keep the result short and globally unique even when bidIds
+// contain long bech32 addresses.
+func scannerActiveBidName(deploymentName, bidId string) string {
+	sum := sha256.Sum256([]byte(bidId))
+	return fmt.Sprintf("%s-bid-%x", deploymentName, sum[:6])
+}
+


### PR DESCRIPTION
## Summary
- New scanner reconciler in `internal/controller/activebid/scanner.go` watches Deployment CRs and creates one ActiveBid CR per chain bid, owned by the parent Deployment so K8s GC cascades on delete
- ActiveBid Observe now mirrors chain `Bid_State` directly (open/active/lost/closed) instead of freezing at "received"
- Observe returns `ResourceExists=false` during deletion or when the parent Deployment is gone, so the managed-resource finalizer clears immediately instead of looping

Keeps the lifecycle inside one module — ActiveBid is producer + observer, BidPolicy stays a policy store.

## Verified on sandbox-2
- Apply Deployment → 2 ActiveBid CRs auto-appear with `state=open`
- After ~5min bid window: `state` flips to `closed` and Deployment Phase to `Expired`
- Delete Deployment → ownerReference cascade → ActiveBids GC'd

## Test plan
- [x] `go build ./...` and `go test ./...`
- [x] Apply Deployment on sandbox-2; verify ActiveBid CRs appear and refresh state
- [x] Delete Deployment; verify ActiveBids removed via cascade