### PR TITLE
fix CodeQL permissions to upload SARIF

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,11 @@ on:
       - release-*
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
 jobs:
   detect-noop:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- CodeQL analysis was failing on main with `Resource not accessible by integration` when uploading SARIF.
- Add a workflow-level `permissions:` block granting `security-events: write` (and read scopes for `contents` and `actions`) so the analyze step can publish results to the Security tab.

## Test plan
- [ ] CodeQL run on main after merge succeeds and uploads results.