### PR TITLE
#38: Add short documentation under ./docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Crossplane provider enables you to manage and reconcile Akash Network resou
 ### Prerequisites
 
 - [Crossplane](https://crossplane.io) installed in your Kubernetes cluster.
-- Akash CLI configured and accessible from the Kubernetes nodes.
+- An Akash wallet funded with [minted ACT](https://akash.network/docs/developers/deployment/cli/act-mint-burn/) and AKT (gas).
 
 
 ## Install
@@ -50,7 +50,7 @@ Check out the `examples/` directory for more sample configurations and usage sce
 ## Troubleshooting
 
 - **Logs**: Check the Crossplane provider logs for any errors during reconciliation.
-- **Akash CLI**: Verify the state of your deployments using the Akash CLI.
+- **Status**: Verify the state of your resources via `kubectl get/describe` — each CR's `status.atProvider` reflects the live on-chain state.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This Crossplane provider enables you to manage and reconcile Akash Network resou
 To install the Akash provider without modifications, use the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
 ```console
-crossplane xpkg install provider xpkg.upbound.io/web7/provider-akash:v0.1.0
+crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
 ```
 
 You can also manually install the Akash provider by creating a Provider directly:
@@ -32,7 +32,7 @@ kind: Provider
 metadata:
   name: provider-akash
 spec:
-  package: xpkg.upbound.io/web7/provider-akash:v0.1.0
+  package: xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Crossplane Akash Provider
+# Crossplane Akash Network Provider
 
 This Crossplane provider enables you to manage and reconcile Akash Network resources, such as deployments, directly from your Kubernetes cluster using Crossplane.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# provider-akash
+
+`provider-akash` is a [Crossplane](https://crossplane.io) provider that lets you manage [Akash Network](https://akash.network) resources declaratively from Kubernetes.
+
+## What it does
+
+The provider reconciles Kubernetes custom resources against the Akash Network chain and provider API:
+
+- Submits and closes deployments on-chain
+- Monitors bids and applies selection policies
+- Creates leases by accepting chosen bids
+- Sends manifests to Akash providers over mTLS
+- Manages TLS certificates used for provider communication
+
+## Resource overview
+
+| Resource | API group | Scope | Purpose |
+|---|---|---|---|
+| `ProviderConfig` | `akash.overlock.network/v1alpha1` | Cluster | Akash credentials and node settings |
+| `SDL` | `akash.overlock.network/v1alpha1` | Namespaced | Stack Definition Language workload spec |
+| `Deployment` | `akash.overlock.network/v1alpha1` | Cluster | On-chain deployment (references SDL) |
+| `BidPolicy` | `akash.overlock.network/v1alpha1` | Cluster | Bid selection rules; optionally auto-creates Leases |
+| `Certificate` | `akash.overlock.network/v1alpha1` | Cluster | TLS certificate for provider mTLS |
+| `Lease` | `akash.overlock.network/v1alpha1` | Cluster | Accepted lease for a Deployment/Bid pair |
+| `Manifest` | `akash.overlock.network/v1alpha1` | Cluster | Sends the workload manifest to the provider |
+
+## Typical resource flow
+
+```
+SDL --> Deployment --> (BidPolicy selects bid) --> Lease --> Manifest
+                                                    ^
+                                              Certificate
+```
+
+## Links
+
+- [Getting started](./getting-started.md)
+- [ProviderConfig](./resources/providerconfig.md)
+- [SDL](./resources/sdl.md)
+- [Deployment](./resources/deployment.md)
+- [BidPolicy](./resources/bidpolicy.md)
+- [Certificate](./resources/certificate.md)
+- [Lease](./resources/lease.md)
+- [Manifest](./resources/manifest.md)
+- [Examples](../examples/)
+- [Akash Network docs](https://akash.network/docs)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,203 @@
+# Getting started
+
+## Prerequisites
+
+- Kubernetes cluster with [Crossplane](https://crossplane.io) installed
+- An Akash wallet with sufficient AKT balance (minimum 0.5 AKT per deployment deposit)
+- Access to an Akash RPC node (defaults to `https://rpc.akashnet.io:443`)
+
+## Install the provider
+
+Using the Crossplane CLI:
+
+```sh
+crossplane xpkg install provider xpkg.upbound.io/web7/provider-akash:v0.1.0
+```
+
+Or via a `Provider` manifest:
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-akash
+spec:
+  package: xpkg.upbound.io/web7/provider-akash:v0.1.0
+```
+
+Wait for the provider to become healthy:
+
+```sh
+kubectl get providers
+```
+
+## Configure credentials
+
+Create a Secret containing your Akash wallet key (base64-encoded mnemonic or key export):
+
+```sh
+kubectl create secret generic akash-credentials \
+  --from-literal=credentials="$(cat ~/.akash/key-export)" \
+  --namespace crossplane-system
+```
+
+Create a `ProviderConfig` referencing the Secret:
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: akash-credentials
+      key: credentials
+  configuration:
+    keyName: default
+    keyringBackend: test
+    net: mainnet
+    chainId: akashnet-2
+    node: "https://rpc.akashnet.io:443"
+```
+
+Apply and verify:
+
+```sh
+kubectl apply -f providerconfig.yaml
+kubectl get providerconfig default
+```
+
+## Deploy a workload
+
+A minimal deployment follows this sequence:
+
+### 1. Define the workload (SDL)
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: SDL
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    version: "2.0"
+    services:
+      web:
+        image: nginx:1.21.6
+        expose:
+          - port: 80
+            as: 80
+            to:
+              - global: true
+    profiles:
+      compute:
+        web:
+          resources:
+            cpu: "0.5"
+            memory: "512Mi"
+            storage:
+              - size: "1Gi"
+      placement:
+        westcoast:
+          pricing:
+            web:
+              amount: 100
+    deployment:
+      web:
+        profile: westcoast
+        count: 1
+```
+
+### 2. Create the on-chain deployment
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    sdlRef:
+      name: my-app
+      namespace: default
+    deposit: 5000000
+```
+
+Watch the deployment reach `Bidding` phase:
+
+```sh
+kubectl get deployment my-app
+# PHASE column should show: Bidding
+```
+
+### 3. Select a bid (BidPolicy)
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: BidPolicy
+metadata:
+  name: my-app
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    deploymentRef:
+      name: my-app
+    selectionStrategy: lowest-price
+    autoAccept: true
+```
+
+With `autoAccept: true` the controller creates a `Lease` automatically once a qualifying bid is found.
+
+### 4. Create a certificate (for mTLS)
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Certificate
+metadata:
+  name: my-app-cert
+spec:
+  providerConfigRef:
+    name: default
+  writeConnectionSecretToRef:
+    name: my-app-cert-tls
+    namespace: default
+  forProvider:
+    domains:
+      - my-app.example.com
+    autoRenew: true
+    validityDays: 365
+```
+
+### 5. Send the manifest
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Manifest
+metadata:
+  name: my-app
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    leaseRef:
+      name: my-app-<generated-by-bidpolicy>
+    certificateSecretRef:
+      name: my-app-cert-tls
+      namespace: default
+```
+
+Once the `Manifest` is `Ready`, your workload is running on Akash. Check `status.atProvider.services` for URIs.
+
+## Next steps
+
+- See each [resource reference](./README.md#links) for full field documentation.
+- Explore the [`examples/`](../examples/) directory for ready-to-apply manifests.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Kubernetes cluster with [Crossplane](https://crossplane.io) installed
-- An Akash wallet with sufficient AKT balance (minimum 0.5 AKT per deployment deposit)
+- An Akash wallet funded with [**minted ACT**](https://akash.network/docs/developers/deployment/cli/act-mint-burn/) (deposits and lease pricing) and **AKT** (transaction gas)
 - Access to an Akash RPC node (defaults to `https://rpc.akashnet.io:443`)
 
 ## Install the provider
@@ -33,15 +33,35 @@ kubectl get providers
 
 ## Configure credentials
 
-Create a Secret containing your Akash wallet key (base64-encoded mnemonic or key export):
+Export your Akash wallet to the ASCII-armored format the cosmos-sdk keyring expects:
 
 ```sh
-kubectl create secret generic akash-credentials \
-  --from-literal=credentials="$(cat ~/.akash/key-export)" \
-  --namespace crossplane-system
+akash keys export <key-name> --keyring-backend <os|test>
+# prompts for an encryption passphrase — remember it
 ```
 
-Create a `ProviderConfig` referencing the Secret:
+Create a Secret with the armored block under `privateKey` and the passphrase under `passphrase`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: akash-credentials
+  namespace: crossplane-system
+type: Opaque
+stringData:
+  privateKey: |
+    -----BEGIN TENDERMINT PRIVATE KEY-----
+    salt: <...>
+    type: secp256k1
+    kdf: bcrypt
+
+    <armored-body>
+    -----END TENDERMINT PRIVATE KEY-----
+  passphrase: "<passphrase-used-during-export>"
+```
+
+Create a `ProviderConfig` that references both:
 
 ```yaml
 apiVersion: akash.overlock.network/v1alpha1
@@ -54,7 +74,13 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: akash-credentials
-      key: credentials
+      key: privateKey
+  passphrase:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: akash-credentials
+      key: passphrase
   configuration:
     keyName: default
     keyringBackend: test
@@ -107,7 +133,7 @@ spec:
         westcoast:
           pricing:
             web:
-              amount: 100
+              amount: 100        # uact per block (denom is hard-coded to uact under v2 BME)
     deployment:
       web:
         profile: westcoast
@@ -128,8 +154,10 @@ spec:
     sdlRef:
       name: my-app
       namespace: default
-    deposit: 5000000
+    deposit: 5000000           # uact (5 ACT). Minimum 500000, denom hard-coded to uact.
 ```
+
+> Gas for the underlying `MsgCreateDeployment` is paid separately in `uakt` from the wallet referenced by the ProviderConfig.
 
 Watch the deployment reach `Bidding` phase:
 
@@ -157,45 +185,17 @@ spec:
 
 With `autoAccept: true` the controller creates a `Lease` automatically once a qualifying bid is found.
 
-### 4. Create a certificate (for mTLS)
+### 4. Lease, Certificate, and Manifest are auto-created
 
-```yaml
-apiVersion: akash.overlock.network/v1alpha1
-kind: Certificate
-metadata:
-  name: my-app-cert
-spec:
-  providerConfigRef:
-    name: default
-  writeConnectionSecretToRef:
-    name: my-app-cert-tls
-    namespace: default
-  forProvider:
-    domains:
-      - my-app.example.com
-    autoRenew: true
-    validityDays: 365
+Once the `Lease` is `Ready`, the lease controller creates a `Certificate` (per ProviderConfig) and a `Manifest` (per Lease) for you, and the manifest controller delivers the SDL to the provider over mTLS.
+
+Watch progress:
+
+```sh
+kubectl get lease,certificate,manifest
 ```
 
-### 5. Send the manifest
-
-```yaml
-apiVersion: akash.overlock.network/v1alpha1
-kind: Manifest
-metadata:
-  name: my-app
-spec:
-  providerConfigRef:
-    name: default
-  forProvider:
-    leaseRef:
-      name: my-app-<generated-by-bidpolicy>
-    certificateSecretRef:
-      name: my-app-cert-tls
-      namespace: default
-```
-
-Once the `Manifest` is `Ready`, your workload is running on Akash. Check `status.atProvider.services` for URIs.
+When the `Manifest` reports `Ready`, the workload is running. Check `status.atProvider.services` on the Manifest for service URIs.
 
 ## Next steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@
 Using the Crossplane CLI:
 
 ```sh
-crossplane xpkg install provider xpkg.upbound.io/web7/provider-akash:v0.1.0
+crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
 ```
 
 Or via a `Provider` manifest:
@@ -22,7 +22,7 @@ kind: Provider
 metadata:
   name: provider-akash
 spec:
-  package: xpkg.upbound.io/web7/provider-akash:v0.1.0
+  package: xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
 ```
 
 Wait for the provider to become healthy:

--- a/docs/resources/bidpolicy.md
+++ b/docs/resources/bidpolicy.md
@@ -13,7 +13,7 @@ Defines bid selection rules for one or more `Deployment` CRs. The controller wat
 | `deploymentRef.name` | one of these | — | Target a single `Deployment` CR by name |
 | `selector` | one of these | — | Label selector matching multiple `Deployment` CRs |
 | `autoAccept` | no | `false` | Automatically create a `Lease` for the selected bid |
-| `maxPrice` | no | — | Maximum acceptable price per block in uact |
+| `maxPrice` | no | — | Maximum acceptable bid price per block in `uact` (denom is `uact` under v2 BME) |
 | `minProviderScore` | no | — | Minimum provider reputation score (0–100) |
 | `requiredAttributes` | no | — | List of `{key, value}` provider attributes that must match |
 | `excludedProviders` | no | — | Provider addresses to ignore |

--- a/docs/resources/bidpolicy.md
+++ b/docs/resources/bidpolicy.md
@@ -1,0 +1,81 @@
+# BidPolicy
+
+**API:** `akash.overlock.network/v1alpha1`
+**Kind:** `BidPolicy`
+**Scope:** Cluster
+
+Defines bid selection rules for one or more `Deployment` CRs. The controller watches incoming bids on-chain, filters them against the policy criteria, selects the best bid, and — when `autoAccept: true` — creates a `Lease` CR automatically.
+
+## Spec fields (`forProvider`)
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `deploymentRef.name` | one of these | — | Target a single `Deployment` CR by name |
+| `selector` | one of these | — | Label selector matching multiple `Deployment` CRs |
+| `autoAccept` | no | `false` | Automatically create a `Lease` for the selected bid |
+| `maxPrice` | no | — | Maximum acceptable price per block in uact |
+| `minProviderScore` | no | — | Minimum provider reputation score (0–100) |
+| `requiredAttributes` | no | — | List of `{key, value}` provider attributes that must match |
+| `excludedProviders` | no | — | Provider addresses to ignore |
+| `preferredProviders` | no | — | Provider addresses given priority during selection |
+| `selectionStrategy` | no | `lowest-price` | How to rank qualifying bids: `lowest-price`, `best-score`, `preferred-first` |
+| `maxBids` | no | `10` | Stop collecting bids after this many are received |
+
+## Status fields (`atProvider`)
+
+| Field | Description |
+|---|---|
+| `state` | Policy state: `active`, `paused`, or `failed` |
+| `matchedDeployments` | Deployment CRs matched by selector |
+| `totalBidsReceived` | Total bids received across matched deployments |
+| `eligibleBids` | Bids that passed all filter criteria |
+| `selectedBids` | Map of deployment name to selected `ActiveBid` reference |
+| `createdLeases` | Map of deployment name to created `Lease` reference |
+| `rejectedBids` | List of rejected bids with reasons |
+| `lastEvaluated` | Timestamp of last evaluation |
+
+## Minimal example
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: BidPolicy
+metadata:
+  name: my-app
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    deploymentRef:
+      name: my-app
+    selectionStrategy: lowest-price
+    autoAccept: true
+    maxPrice: 500
+```
+
+## Example with label selector
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: BidPolicy
+metadata:
+  name: frontend-policy
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    selector:
+      matchLabels:
+        tier: frontend
+    selectionStrategy: best-score
+    minProviderScore: 70
+    requiredAttributes:
+      - key: region
+        value: us-west
+    autoAccept: true
+```
+
+## Lifecycle notes
+
+- **Create:** The controller begins watching bids for matched deployments. If `autoAccept: true`, it creates a `Lease` CR once a bid is selected.
+- **Update:** Criteria changes take effect on the next evaluation cycle. Already-created Leases are not revoked.
+- **Delete:** Stops bid monitoring. Leases previously created by this policy are not deleted.

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -6,6 +6,16 @@
 
 Manages a TLS certificate used for mTLS communication with Akash providers. The certificate is registered on-chain and the keypair is published to a Kubernetes Secret via `writeConnectionSecretToRef`. The `Manifest` CR references this Secret to authenticate against the provider.
 
+> Normally you do **not** create this resource yourself. The Lease controller auto-creates one `Certificate` per `ProviderConfig` when the first Lease becomes Ready, and reuses it across leases. Create one manually only if you need a custom domain set or validity window.
+
+## Auto-created naming
+
+When auto-created by the Lease controller:
+- `metadata.name` is `<providerconfig-name>-cert`
+- `writeConnectionSecretToRef.name` is `<providerconfig-name>-cert-secret`
+- `writeConnectionSecretToRef.namespace` matches the parent Lease's namespace
+- The Certificate self-deletes when its `ProviderConfig` is deleted
+
 ## Spec fields (`forProvider`)
 
 | Field | Required | Default | Description |

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -1,0 +1,57 @@
+# Certificate
+
+**API:** `akash.overlock.network/v1alpha1`
+**Kind:** `Certificate`
+**Scope:** Cluster
+
+Manages a TLS certificate used for mTLS communication with Akash providers. The certificate is registered on-chain and the keypair is published to a Kubernetes Secret via `writeConnectionSecretToRef`. The `Manifest` CR references this Secret to authenticate against the provider.
+
+## Spec fields (`forProvider`)
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `domains` | yes | — | List of domain names for the certificate |
+| `deploymentRef.name` | no | — | Optional reference to an associated `Deployment` CR |
+| `deploymentRef.namespace` | no | — | Namespace of the referenced Deployment |
+| `autoRenew` | no | `true` | Automatically renew before expiry |
+| `validityDays` | no | `365` | Certificate validity period in days (1–3650) |
+
+## Status fields (`atProvider`)
+
+| Field | Description |
+|---|---|
+| `serial` | Certificate serial number |
+| `owner` | Owner address from ProviderConfig |
+| `state` | Certificate state: `valid`, `expired`, or `revoked` |
+| `fingerprint` | Certificate fingerprint |
+| `pem` | Certificate PEM content |
+| `notBefore` / `notAfter` | Validity window (Unix timestamps) |
+| `createdAt` / `expiresAt` / `lastRenewed` | Lifecycle timestamps |
+
+## Minimal example
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Certificate
+metadata:
+  name: my-app-cert
+spec:
+  providerConfigRef:
+    name: default
+  writeConnectionSecretToRef:
+    name: my-app-cert-tls
+    namespace: default
+  forProvider:
+    domains:
+      - my-app.example.com
+    autoRenew: true
+    validityDays: 365
+```
+
+The Secret named `my-app-cert-tls` will contain `tls.crt` and `tls.key` keys used by the `Manifest` CR.
+
+## Lifecycle notes
+
+- **Create:** Generates a keypair and registers the certificate on the Akash chain. Publishes `tls.crt` / `tls.key` to the connection Secret.
+- **Update:** Changing `domains` or `validityDays` triggers certificate re-issuance on-chain.
+- **Delete:** Revokes the certificate on the Akash chain. The connection Secret is deleted by Crossplane.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -12,7 +12,7 @@ Represents an on-chain Akash deployment. The controller submits a `MsgCreateDepl
 |---|---|---|---|
 | `sdlRef.name` | yes | — | Name of the `SDL` CR |
 | `sdlRef.namespace` | no | same namespace | Namespace of the `SDL` CR |
-| `deposit` | no | `5000000` | Escrow deposit in uact (min `500000`) |
+| `deposit` | no | `5000000` | Escrow deposit amount in `uact` (min `500000`). Denom is hard-coded to `uact` under v2 BME — only the integer amount is configurable. Gas for the broadcast is paid separately in `uakt`. |
 
 ## Status fields (`atProvider`)
 
@@ -27,7 +27,7 @@ Represents an on-chain Akash deployment. The controller submits a `MsgCreateDepl
 | `bids` | Total bids ever recorded (stays >0 after bid window) |
 | `leasesActive` | Number of active leases |
 | `createdHeight` | Block height at creation |
-| `escrowBalance` | Current escrow `{denom, amount}` |
+| `escrowBalance` | Current escrow `{denom: uact, amount}` (denom is always `uact` under v2 BME) |
 
 ### Phase values
 

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -1,0 +1,66 @@
+# Deployment
+
+**API:** `akash.overlock.network/v1alpha1`
+**Kind:** `Deployment`
+**Scope:** Cluster
+
+Represents an on-chain Akash deployment. The controller submits a `MsgCreateDeployment` transaction when the resource is created and a `MsgCloseDeployment` when it is deleted.
+
+## Spec fields (`forProvider`)
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `sdlRef.name` | yes | — | Name of the `SDL` CR |
+| `sdlRef.namespace` | no | same namespace | Namespace of the `SDL` CR |
+| `deposit` | no | `5000000` | Escrow deposit in uact (min `500000`) |
+
+## Status fields (`atProvider`)
+
+| Field | Description |
+|---|---|
+| `deploymentId` | On-chain deployment sequence number (dseq) |
+| `owner` | Wallet address that owns the deployment |
+| `state` | Raw chain state: `active` or `closed` |
+| `phase` | Derived lifecycle phase (see below) |
+| `ordersOpen` | Number of open orders on-chain |
+| `bidsOpen` | Number of bids currently in `Open` state |
+| `bids` | Total bids ever recorded (stays >0 after bid window) |
+| `leasesActive` | Number of active leases |
+| `createdHeight` | Block height at creation |
+| `escrowBalance` | Current escrow `{denom, amount}` |
+
+### Phase values
+
+| Phase | Meaning |
+|---|---|
+| `Pending` | Not yet broadcast to chain |
+| `Bidding` | Order open; providers are bidding |
+| `Leased` | At least one active lease |
+| `Expired` | No open orders and no active leases (bid window passed) |
+| `Closed` | Chain closed the deployment (escrow drained or owner closed) |
+
+## Minimal example
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    sdlRef:
+      name: my-app
+      namespace: default
+    deposit: 5000000
+  writeConnectionSecretToRef:
+    name: my-app-connection
+    namespace: default
+```
+
+## Lifecycle notes
+
+- **Create:** Broadcasts `MsgCreateDeployment` on-chain and transitions to `Bidding` once the order appears.
+- **Update:** If the referenced SDL changes (hash differs), the controller broadcasts `MsgUpdateDeployment`.
+- **Delete:** Broadcasts `MsgCloseDeployment`, which also closes any open orders; active leases are unaffected until their escrow runs out.

--- a/docs/resources/lease.md
+++ b/docs/resources/lease.md
@@ -1,0 +1,59 @@
+# Lease
+
+**API:** `akash.overlock.network/v1alpha1`
+**Kind:** `Lease`
+**Scope:** Cluster
+
+Represents an Akash lease — the agreement between a tenant and a provider to run a workload. The controller sends a `MsgCreateLease` transaction that accepts the chosen bid. Leases are typically created automatically by a `BidPolicy` with `autoAccept: true`, but can also be created manually.
+
+## Spec fields (`forProvider`)
+
+| Field | Required | Description |
+|---|---|---|
+| `deploymentRef.name` | yes | Name of the `Deployment` CR |
+| `deploymentRef.namespace` | no | Namespace of the `Deployment` CR |
+| `activeBidRef.name` | yes | Name of the `ActiveBid` CR to accept |
+| `activeBidRef.namespace` | no | Namespace of the `ActiveBid` CR |
+| `activeBidRef.bidId` | no | Bid ID (informational) |
+| `activeBidRef.provider` | no | Provider address (informational) |
+| `activeBidRef.price` | no | Bid price in uact (informational) |
+
+## Status fields (`atProvider`)
+
+| Field | Description |
+|---|---|
+| `leaseId` | Unique lease identifier on Akash (`owner/dseq/gseq/oseq/provider`) |
+| `owner` | Deployment owner address |
+| `dseq` | Deployment sequence number |
+| `gseq` | Group sequence number |
+| `oseq` | Order sequence number |
+| `provider` | Provider address |
+| `state` | Lease state: `active` or `closed` |
+| `price` | Accepted bid price info |
+| `createdAt` | Lease creation timestamp |
+| `services` | Running services: name, availability, URIs, port mappings |
+
+## Minimal example
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Lease
+metadata:
+  name: my-app-lease
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    deploymentRef:
+      name: my-app
+      namespace: default
+    activeBidRef:
+      name: my-app-activebid
+      namespace: default
+```
+
+## Lifecycle notes
+
+- **Create:** Sends `MsgCreateLease` on-chain, accepting the specified bid. The provider begins scheduling the workload.
+- **Update:** Lease parameters cannot be changed after creation. The controller reconciles observed state only.
+- **Delete:** Sends `MsgCloseLease` on-chain, stopping the workload on the provider. The escrow for that group is returned to the tenant.

--- a/docs/resources/lease.md
+++ b/docs/resources/lease.md
@@ -57,3 +57,4 @@ spec:
 - **Create:** Sends `MsgCreateLease` on-chain, accepting the specified bid. The provider begins scheduling the workload.
 - **Update:** Lease parameters cannot be changed after creation. The controller reconciles observed state only.
 - **Delete:** Sends `MsgCloseLease` on-chain, stopping the workload on the provider. The escrow for that group is returned to the tenant.
+- **Side effects when active:** the Lease controller auto-creates a `Certificate` (per ProviderConfig) and a `Manifest` (per Lease) once the lease is Ready. The Manifest is owned by the Lease so it is garbage-collected when the Lease is closed.

--- a/docs/resources/manifest.md
+++ b/docs/resources/manifest.md
@@ -1,0 +1,58 @@
+# Manifest
+
+**API:** `akash.overlock.network/v1alpha1`
+**Kind:** `Manifest`
+**Scope:** Cluster
+
+Sends the workload manifest to the Akash provider over mTLS. This is the final step before a workload becomes running. The controller resolves the lease coordinates from the `Lease` CR, reads the mTLS keypair from the certificate Secret, and pushes the SDL-derived manifest to the provider's HTTP API.
+
+## Spec fields (`forProvider`)
+
+| Field | Required | Description |
+|---|---|---|
+| `leaseRef.name` | yes | Name of the `Lease` CR |
+| `leaseRef.namespace` | no | Namespace of the `Lease` CR |
+| `certificateSecretRef.name` | yes | Name of the Secret containing `tls.crt` / `tls.key` |
+| `certificateSecretRef.namespace` | no | Namespace of the certificate Secret |
+
+The certificate Secret is typically the one published by a `Certificate` CR via `writeConnectionSecretToRef`.
+
+## Status fields (`atProvider`)
+
+| Field | Description |
+|---|---|
+| `state` | Manifest state: `pending`, `deployed`, or `failed` |
+| `owner` | Deployment owner (from Lease) |
+| `dseq` / `gseq` / `oseq` | Lease sequence numbers (from Lease) |
+| `provider` | Provider address (from Lease) |
+| `sdlContent` | Rendered SDL sent to provider |
+| `manifestVersion` | Content hash of the deployed manifest |
+| `deployedAt` | Timestamp when manifest was sent |
+| `services` | List of service definitions from the manifest |
+| `validationErrors` | Validation errors reported by the provider |
+| `providerResponse` | Raw response from provider |
+
+## Minimal example
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Manifest
+metadata:
+  name: my-app
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    leaseRef:
+      name: my-app-lease
+      namespace: default
+    certificateSecretRef:
+      name: my-app-cert-tls
+      namespace: default
+```
+
+## Lifecycle notes
+
+- **Create:** Resolves the lease coordinates, renders the SDL into a manifest, and sends it to the provider via mTLS. State moves to `deployed` on success.
+- **Update:** If the underlying SDL changes (detected via `manifestVersion` hash), the controller re-sends the updated manifest to the provider.
+- **Delete:** No on-chain transaction. The provider will continue running the workload until the `Lease` is closed.

--- a/docs/resources/manifest.md
+++ b/docs/resources/manifest.md
@@ -6,6 +6,8 @@
 
 Sends the workload manifest to the Akash provider over mTLS. This is the final step before a workload becomes running. The controller resolves the lease coordinates from the `Lease` CR, reads the mTLS keypair from the certificate Secret, and pushes the SDL-derived manifest to the provider's HTTP API.
 
+> Normally you do **not** create this resource yourself. The Lease controller auto-creates one `Manifest` per `Lease` once the lease is active, wired to the auto-created `Certificate`'s Secret, and owned by the Lease so Kubernetes GC removes it when the Lease is closed. Create one manually only if you need to override the default certificate Secret reference.
+
 ## Spec fields (`forProvider`)
 
 | Field | Required | Description |

--- a/docs/resources/providerconfig.md
+++ b/docs/resources/providerconfig.md
@@ -1,0 +1,59 @@
+# ProviderConfig
+
+**API:** `akash.overlock.network/v1alpha1`
+**Kind:** `ProviderConfig`
+**Scope:** Cluster
+
+Holds the Akash wallet credentials and node connection settings used by all other resources. Every managed resource has a `providerConfigRef` that points to one of these.
+
+## Spec fields
+
+### `credentials` (required)
+
+| Field | Description |
+|---|---|
+| `source` | Where to read the credential. One of `None`, `Secret`, `InjectedIdentity`, `Environment`, `Filesystem` |
+| `secretRef.namespace` | Namespace of the Secret |
+| `secretRef.name` | Name of the Secret |
+| `secretRef.key` | Key inside the Secret holding the wallet key export |
+
+### `passphrase` (optional)
+
+Same shape as `credentials`. Used when the key export is encrypted.
+
+### `configuration` (optional)
+
+| Field | Default | Description |
+|---|---|---|
+| `keyName` | `default` | Name of the key in the keyring |
+| `keyringBackend` | `test` | Keyring backend (`os`, `file`, `test`, `memory`) |
+| `accountAddress` | — | Akash address override (auto-derived if omitted) |
+| `net` | `mainnet` | Network (`mainnet`, `testnet`, `sandbox`) |
+| `chainId` | `akashnet-2` | Chain ID |
+| `node` | `https://rpc.akashnet.io:443` | RPC endpoint |
+| `home` | `/tmp/.akash` | Akash home directory |
+| `path` | `/usr/local/bin/akash` | Path to the `akash` binary |
+| `providersApi` | `https://akash-api.polkachu.com` | Providers REST API base URL |
+| `skipTLSVerification` | `false` | Skip TLS verification (dev/test only) |
+
+## Minimal example
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: akash-credentials
+      key: credentials
+```
+
+## Lifecycle notes
+
+- `ProviderConfig` is not itself an on-chain resource; it is never created or deleted on Akash.
+- Changing `configuration` fields takes effect on the next reconciliation of any resource that references this config.
+- Deleting a `ProviderConfig` while resources still reference it will block those resources from reconciling.

--- a/docs/resources/providerconfig.md
+++ b/docs/resources/providerconfig.md
@@ -10,16 +10,18 @@ Holds the Akash wallet credentials and node connection settings used by all othe
 
 ### `credentials` (required)
 
+Reference to the wallet key in ASCII-armored format produced by `akash keys export <key-name> --keyring-backend <os|test>` (the block starting with `-----BEGIN TENDERMINT PRIVATE KEY-----`).
+
 | Field | Description |
 |---|---|
 | `source` | Where to read the credential. One of `None`, `Secret`, `InjectedIdentity`, `Environment`, `Filesystem` |
 | `secretRef.namespace` | Namespace of the Secret |
 | `secretRef.name` | Name of the Secret |
-| `secretRef.key` | Key inside the Secret holding the wallet key export |
+| `secretRef.key` | Key inside the Secret holding the armored private key |
 
-### `passphrase` (optional)
+### `passphrase` (required when the key is encrypted)
 
-Same shape as `credentials`. Used when the key export is encrypted.
+Same shape as `credentials`. Holds the passphrase entered during `akash keys export`. The cosmos-sdk keyring uses this to decrypt the armored block — without it the controller cannot import the key.
 
 ### `configuration` (optional)
 
@@ -49,7 +51,13 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: akash-credentials
-      key: credentials
+      key: privateKey
+  passphrase:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: akash-credentials
+      key: passphrase
 ```
 
 ## Lifecycle notes

--- a/docs/resources/sdl.md
+++ b/docs/resources/sdl.md
@@ -1,0 +1,107 @@
+# SDL
+
+**API:** `akash.overlock.network/v1alpha1`
+**Kind:** `SDL`
+**Scope:** Namespaced
+
+An SDL (Stack Definition Language) resource describes the workload to be deployed on Akash: container images, resource requirements, placement constraints, and pricing. It is referenced by a `Deployment` CR and is not itself submitted on-chain directly.
+
+## Spec fields (`forProvider`)
+
+| Field | Required | Description |
+|---|---|---|
+| `version` | yes | SDL version — must be `"2.0"` |
+| `services` | yes | Map of service name to service definition |
+| `profiles` | yes | Compute and placement profiles |
+| `deployment` | yes | Binds services to placement profiles with instance counts |
+
+### `services.<name>`
+
+| Field | Description |
+|---|---|
+| `image` | Docker image (required) |
+| `command` | Override container entrypoint |
+| `args` | Arguments for the command |
+| `env` | List of `KEY=value` environment strings |
+| `expose` | List of port exposure rules (see below) |
+| `params.storage` | Map of named storage mounts (`mount`, `readOnly`) |
+
+### `expose` entry
+
+| Field | Description |
+|---|---|
+| `port` | Container port |
+| `as` | External port (defaults to `port`) |
+| `proto` | `tcp` (default) or `udp` |
+| `to` | List of `{global: true}` or `{service: <name>}` |
+| `accept.items` | Accepted hostnames for HTTP ingress |
+
+### `profiles.compute.<name>.resources`
+
+| Field | Example | Description |
+|---|---|---|
+| `cpu` | `"0.5"` | CPU units (fractional or millicores) |
+| `memory` | `"512Mi"` | Memory (Ki, Mi, Gi, Ti) |
+| `storage` | `[{size: "1Gi"}]` | Ephemeral storage list |
+| `gpu.units` | `1` | Number of GPU units |
+
+### `profiles.placement.<name>`
+
+| Field | Description |
+|---|---|
+| `attributes` | Map of provider attributes to require |
+| `signedBy.anyOf` | Require signature from any listed address |
+| `pricing.<service>.amount` | Max price per block in uact |
+
+### `deployment.<service>`
+
+| Field | Description |
+|---|---|
+| `profile` | Name of a placement profile |
+| `count` | Number of instances (1–100) |
+
+## Minimal example
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: SDL
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    version: "2.0"
+    services:
+      web:
+        image: nginx:1.21.6
+        expose:
+          - port: 80
+            as: 80
+            to:
+              - global: true
+    profiles:
+      compute:
+        web:
+          resources:
+            cpu: "0.5"
+            memory: "512Mi"
+            storage:
+              - size: "1Gi"
+      placement:
+        westcoast:
+          pricing:
+            web:
+              amount: 100
+    deployment:
+      web:
+        profile: westcoast
+        count: 1
+```
+
+## Lifecycle notes
+
+- **Create:** The SDL is validated and a content hash is stored in `status.atProvider.hash`. No on-chain transaction is triggered.
+- **Update:** Any change to `forProvider` recomputes the hash. Dependent `Deployment` CRs detect the new hash and re-broadcast an updated deployment on-chain.
+- **Delete:** Safe to delete once no `Deployment` references this SDL.

--- a/docs/resources/sdl.md
+++ b/docs/resources/sdl.md
@@ -51,7 +51,7 @@ An SDL (Stack Definition Language) resource describes the workload to be deploye
 |---|---|
 | `attributes` | Map of provider attributes to require |
 | `signedBy.anyOf` | Require signature from any listed address |
-| `pricing.<service>.amount` | Max price per block in uact |
+| `pricing.<service>.amount` | Max price per block in `uact` (denom is hard-coded to `uact` under v2 BME — only the amount is configurable) |
 
 ### `deployment.<service>`
 


### PR DESCRIPTION
Adds a `docs/` directory with an overview README, getting-started guide, and per-resource reference pages covering `ProviderConfig`, `SDL`, `Deployment`, `BidPolicy`, `Certificate`, `Lease`, and `Manifest`, so users can get started without reading the source code.

## Reference
Closes: https://github.com/overlock-network/provider-akash/issues/38
