### PR TITLE
40: tag pushes now actually publish to Upbound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,4 +249,16 @@ jobs:
 
       - name: Publish Artifacts
         if: github.event_name != 'pull_request' && env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
-        run: make publish BRANCH_NAME=${GITHUB_REF##*/}
+        run: |
+          # The build's publish.artifacts target only fires for
+          # BRANCH_NAME in {main, master, release-*}. On tag pushes
+          # GITHUB_REF##*/ resolves to the tag (e.g. v0.0.1), which
+          # would skip publish entirely; force BRANCH_NAME=main so
+          # the gate passes. VERSION is still derived from git
+          # describe, so the pushed package is tagged with the real
+          # version (e.g. :v0.0.1), not :main.
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            make publish BRANCH_NAME=main
+          else
+            make publish BRANCH_NAME=${GITHUB_REF##*/}
+          fi


### PR DESCRIPTION
## Summary
- Root cause of "publish step green but nothing in Marketplace": upstream `build/makelib/xpkg.mk` only wires `publish.artifacts` when `BRANCH_NAME` matches `main|master|release-*`. On tag pushes `${GITHUB_REF##*/}` is the tag (e.g. `v0.0.1`), which the filter skips, so `make publish` exits in ~500 ms with no output.
- Fix: when `GITHUB_REF` is a tag, pass `BRANCH_NAME=main` so the gate passes. `VERSION` is still derived from `git describe` against the tagged commit, so the package is pushed as `:v0.0.1`, not `:main`. Code in the package comes from the checked-out tagged commit, not `main`'s HEAD.

## Test plan
- [x] After merge, re-push tag `v0.0.1`. CI `Publish Artifacts` step should log `Pushing package xpkg.upbound.io/overlock-network/provider-akash:v0.0.1` and the version should appear in the Upbound Marketplace.