### PR TITLE
40: tag-triggered publish via crossplane-contrib reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - 'v*'
   pull_request: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish Provider Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-provider-package:
+    uses: crossplane-contrib/provider-workflows/.github/workflows/publish-provider.yml@main
+    with:
+      cleanup-disk: true
+      go-version: '1.25'
+      repository: provider-akash
+      version: ${{ github.ref_name }}
+      registry_org: overlock-network
+    secrets:
+      GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
+      XPKG_MIRROR_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
+      XPKG_MIRROR_TOKEN: ${{ secrets.XPKG_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `publish.yml` that delegates to crossplane-contrib's reusable publish workflow (build → GHCR → mirror to `xpkg.upbound.io` via crane).
- Trigger on `v*` tags; tag name becomes the published version.
- Drop the `v*` tag trigger from `ci.yml` so tags only fire `publish.yml`.

Repo secrets: `XPKG_ACCESS_ID`, `XPKG_TOKEN` (Upbound robot creds).

## Test plan
- [ ] Push tag `v0.0.3`; package appears at `xpkg.upbound.io/overlock-network/provider-akash:v0.0.3`.