### PR TITLE
40: grant packages: write to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-provider-package:
     uses: crossplane-contrib/provider-workflows/.github/workflows/publish-provider.yml@main


### PR DESCRIPTION
Fixes 'DENIED: installation not allowed to Create organization package' on first GHCR push during the Publish Provider Package workflow.