### PR TITLE
52: make SDL CRD cluster-scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This Crossplane provider enables you to manage and reconcile Akash Network resou
 To install the Akash provider without modifications, use the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
 ```console
-crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
+crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.0.9
 ```
 
 You can also manually install the Akash provider by creating a Provider directly:
@@ -33,7 +33,7 @@ kind: Provider
 metadata:
   name: provider-akash
 spec:
-  package: xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
+  package: xpkg.upbound.io/overlock-network/provider-akash:v0.0.9
 ```
 
 ## Usage

--- a/apis/resource/v1alpha1/deployment_types.go
+++ b/apis/resource/v1alpha1/deployment_types.go
@@ -51,10 +51,6 @@ type SDLReference struct {
 	// Name is the name of the SDL resource
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
-
-	// Namespace is the namespace of the SDL resource (defaults to same namespace as Deployment)
-	// +optional
-	Namespace string `json:"namespace,omitempty"`
 }
 
 

--- a/apis/resource/v1alpha1/sdl_types.go
+++ b/apis/resource/v1alpha1/sdl_types.go
@@ -332,7 +332,7 @@ type SDLStatus struct {
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.forProvider.version"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced,categories={crossplane,managed,akash}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,akash}
 type SDL struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@
 Using the Crossplane CLI:
 
 ```sh
-crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
+crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.0.9
 ```
 
 Or via a `Provider` manifest:
@@ -22,7 +22,7 @@ kind: Provider
 metadata:
   name: provider-akash
 spec:
-  package: xpkg.upbound.io/overlock-network/provider-akash:v0.1.0
+  package: xpkg.upbound.io/overlock-network/provider-akash:v0.0.9
 ```
 
 Wait for the provider to become healthy:

--- a/examples/deployment/deployment.yaml
+++ b/examples/deployment/deployment.yaml
@@ -11,7 +11,6 @@ spec:
     # Reference the SDL CR that defines the workload
     sdlRef:
       name: simple-web
-      namespace: default
     # Deployment escrow deposit in uact (minimum 500000, default 5000000)
     deposit: 5000000
   # The controller will write connection details (host, ports) into this Secret

--- a/examples/sdl/sdl-gpu.yaml
+++ b/examples/sdl/sdl-gpu.yaml
@@ -2,7 +2,6 @@ apiVersion: akash.overlock.network/v1alpha1
 kind: SDL
 metadata:
   name: gpu-workload
-  namespace: default
 spec:
   providerConfigRef:
     name: default

--- a/examples/sdl/sdl-multi-service.yaml
+++ b/examples/sdl/sdl-multi-service.yaml
@@ -2,7 +2,6 @@ apiVersion: akash.overlock.network/v1alpha1
 kind: SDL
 metadata:
   name: multi-service-app
-  namespace: default
 spec:
   providerConfigRef:
     name: default

--- a/examples/sdl/sdl-persistent-storage.yaml
+++ b/examples/sdl/sdl-persistent-storage.yaml
@@ -2,7 +2,6 @@ apiVersion: akash.overlock.network/v1alpha1
 kind: SDL
 metadata:
   name: postgres-persistent
-  namespace: default
 spec:
   providerConfigRef:
     name: default

--- a/examples/sdl/sdl-simple.yaml
+++ b/examples/sdl/sdl-simple.yaml
@@ -2,7 +2,6 @@ apiVersion: akash.overlock.network/v1alpha1
 kind: SDL
 metadata:
   name: simple-web
-  namespace: default
 spec:
   providerConfigRef:
     name: default

--- a/extensions/readme/readme.md
+++ b/extensions/readme/readme.md
@@ -13,7 +13,7 @@ Manage [Akash Network](https://akash.network) resources declaratively from Kuber
 ## Install
 
 ```bash
-crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.0.6
+crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.0.9
 ```
 
 Or as a manifest:
@@ -24,7 +24,7 @@ kind: Provider
 metadata:
   name: provider-akash
 spec:
-  package: xpkg.upbound.io/overlock-network/provider-akash:v0.0.6
+  package: xpkg.upbound.io/overlock-network/provider-akash:v0.0.9
 ```
 
 ## Prerequisites

--- a/internal/controller/deployment/deployment.go
+++ b/internal/controller/deployment/deployment.go
@@ -651,26 +651,16 @@ func generateSDLHashHex(sdl string) string {
 
 // resolveSDLContent resolves SDL content from SDLRef
 func (c *external) resolveSDLContent(ctx context.Context, cr *v1alpha1.Deployment) (string, error) {
-	// Resolve SDL from SDLRef
 	sdlRef := cr.Spec.ForProvider.SDLRef
-	sdlNamespace := sdlRef.Namespace
-	if sdlNamespace == "" {
-		sdlNamespace = cr.Namespace
-	}
 
-	// Get the SDL resource
 	sdlResource := &v1alpha1.SDL{}
-	if err := c.kube.Get(ctx, types.NamespacedName{
-		Name:      sdlRef.Name,
-		Namespace: sdlNamespace,
-	}, sdlResource); err != nil {
-		return "", errors.Wrapf(err, "failed to get SDL resource %s/%s", sdlNamespace, sdlRef.Name)
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: sdlRef.Name}, sdlResource); err != nil {
+		return "", errors.Wrapf(err, "failed to get SDL resource %s", sdlRef.Name)
 	}
 
-	// Check if SDL is ready/validated
 	if !sdlResource.Status.AtProvider.Validated || len(sdlResource.Status.AtProvider.ValidationErrors) > 0 {
-		return "", errors.Errorf("SDL resource %s/%s is not validated or has validation errors: %v", 
-			sdlNamespace, sdlRef.Name, sdlResource.Status.AtProvider.ValidationErrors)
+		return "", errors.Errorf("SDL resource %s is not validated or has validation errors: %v",
+			sdlRef.Name, sdlResource.Status.AtProvider.ValidationErrors)
 	}
 
 	return client.RenderSDLToYAML(sdlResource)

--- a/internal/controller/manifest/manifest.go
+++ b/internal/controller/manifest/manifest.go
@@ -506,17 +506,9 @@ func (c *external) getReferencedDeployment(ctx context.Context, lease *akashv1al
 func (c *external) getSDLContentFromDeployment(ctx context.Context, deployment *resourcev1alpha1.Deployment) (string, error) {
 	sdlRef := deployment.Spec.ForProvider.SDLRef
 
-	namespace := sdlRef.Namespace
-	if namespace == "" {
-		namespace = deployment.Namespace
-	}
-
 	sdl := &resourcev1alpha1.SDL{}
-	if err := c.kubeClient.Get(ctx, types.NamespacedName{
-		Name:      sdlRef.Name,
-		Namespace: namespace,
-	}, sdl); err != nil {
-		return "", fmt.Errorf("failed to get SDL %s/%s: %w", namespace, sdlRef.Name, err)
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: sdlRef.Name}, sdl); err != nil {
+		return "", fmt.Errorf("failed to get SDL %s: %w", sdlRef.Name, err)
 	}
 
 	sdlYAML, err := c.convertSDLToYAML(sdl)

--- a/package/crds/akash.overlock.network_deployments.yaml
+++ b/package/crds/akash.overlock.network_deployments.yaml
@@ -105,10 +105,6 @@ spec:
                       name:
                         description: Name is the name of the SDL resource
                         type: string
-                      namespace:
-                        description: Namespace is the namespace of the SDL resource
-                          (defaults to same namespace as Deployment)
-                        type: string
                     required:
                     - name
                     type: object

--- a/package/crds/akash.overlock.network_sdls.yaml
+++ b/package/crds/akash.overlock.network_sdls.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: SDLList
     plural: sdls
     singular: sdl
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Ready')].status


### PR DESCRIPTION
Closes #52.

## Summary
- `apis/resource/v1alpha1/sdl_types.go`: `scope=Namespaced` → `Cluster`.
- `apis/resource/v1alpha1/deployment_types.go`: drop `SDLReference.Namespace`.
- `internal/controller/deployment/deployment.go` and `internal/controller/manifest/manifest.go`: drop the namespace-resolution branches around `sdlRef`.
- Examples: drop `namespace:` from `examples/sdl/*.yaml` and `sdlRef.namespace` from `examples/deployment/deployment.yaml`.
- Regenerated CRDs via `make generate`.
- Docs bump: pin install examples in `README.md`, `docs/getting-started.md`, and `extensions/readme/readme.md` to `v0.0.9`.

## Test plan
- [x] `go build ./...` clean.
- [x] `make generate` produces `sdls.yaml` with `scope: Cluster` and `deployments.yaml` schema without the namespace field.
- [x] Apply an SDL (cluster-scoped) and a Deployment referencing it by name only; deployment reconciles.