### PR TITLE
40: drop build-submodule deps from extension targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,23 +114,21 @@ go.mod.cachedir:
 # the repo (assets/icon.svg, docs/marketplace.md); the extensions tree is
 # assembled at build time under $(OUTPUT_DIR)/extensions and never committed.
 
-EXTENSIONS_DIR ?= $(OUTPUT_DIR)/extensions
+EXTENSIONS_DIR ?= _output/extensions
 EXTENSIONS_ICON ?= assets/icon.svg
 EXTENSIONS_README ?= docs/marketplace.md
 EXTENSIONS_IMAGE ?= xpkg.upbound.io/overlock-network/$(PROJECT_NAME):$(VERSION)
 
 package.extensions:
-	@$(INFO) assembling marketplace extensions tree at $(EXTENSIONS_DIR)
+	@echo "Assembling marketplace extensions tree at $(EXTENSIONS_DIR)"
 	@rm -rf $(EXTENSIONS_DIR)
 	@mkdir -p $(EXTENSIONS_DIR)/icons $(EXTENSIONS_DIR)/readme
 	@cp $(EXTENSIONS_ICON) $(EXTENSIONS_DIR)/icons/icon.svg
 	@cp $(EXTENSIONS_README) $(EXTENSIONS_DIR)/readme/readme.md
-	@$(OK) marketplace extensions assembled
 
 publish.extensions: package.extensions
-	@$(INFO) appending marketplace extensions to $(EXTENSIONS_IMAGE)
+	@echo "Appending marketplace extensions to $(EXTENSIONS_IMAGE)"
 	@up alpha xpkg append --extensions-root=$(EXTENSIONS_DIR) $(EXTENSIONS_IMAGE)
-	@$(OK) marketplace extensions appended
 
 .PHONY: submodules fallthrough test-integration run dev dev-clean go.mod.cachedir package.extensions publish.extensions
 


### PR DESCRIPTION
Marketplace extension targets relied on `$(INFO)`/`$(OK)`/`$(OUTPUT_DIR)` from the build submodule, which is not initialised in the publish workflow runner. Use plain `echo` and a literal `_output/extensions` path so the targets are self-contained.