### PR TITLE
40: expand README usage and refresh OWNERS

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,15 +1,9 @@
 # OWNERS
 
-This page lists all maintainers for **this** repository. Each repository in the [Crossplane
-organization](https://github.com/crossplane/) will list their repository maintainers in their own
+This page lists all maintainers for **this** repository. Each repository in the [Overlock Network
+organization](https://github.com/overlock-network/) will list their repository maintainers in their own
 `OWNERS.md` file.
-
-Please see the Crossplane
-[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
-guidelines and responsibilities for the steering committee and maintainers.
 
 ## Maintainers
 
-* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
-* Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
-* Muvaffak Onuş <monus@upbound.io> ([muvaf](https://github.com/muvaf))
+* Evgheni Poleacov <evgheni@overlock.network> ([evgheni7](https://github.com/evgheni7))

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Crossplane Akash Network Provider
 <p align="center"><img src="assets/akash-crossplane.png" alt="Akash Crossplane Logo" width="50%"></p>
 
-This Crossplane provider enables you to manage and reconcile Akash Network resources, such as deployments, directly from your Kubernetes cluster using Crossplane.
+This Crossplane provider enables you to manage and reconcile [Akash Network](https://akash.network) resources, such as deployments, directly from your Kubernetes cluster using Crossplane.
 
 ## Features
 
@@ -40,13 +40,157 @@ spec:
 
 Once installed and configured, the Crossplane Akash provider will reconcile Akash network resources based on your Kubernetes manifests.
 
-- **Create**: New resources will be created on the Akash network.
-- **Update**: Any changes in the manifest will be reflected on the Akash deployment.
-- **Delete**: Deleting the Kubernetes resource will clean up the corresponding Akash resource.
+### Wallet Secret
+
+Holds the base64-encoded Akash wallet export and its passphrase. Referenced by `ProviderConfig` to sign on-chain transactions.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: akash-wallet-secret
+type: Opaque
+data:
+  credentials: "<BASE64_ENCODED_TENDERMINT_PRIVATE_KEY>"
+  passphrase: "<BASE64_ENCODED_PASSPHRASE>"
+```
+
+### ProviderConfig
+
+Connects the provider to a specific Akash network (mainnet or sandbox) and points at the wallet secret used to authenticate transactions.
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: akash-provider
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: default
+      name: akash-wallet-secret
+      key: credentials
+  passphrase:
+    source: Secret
+    secretRef:
+      namespace: default
+      name: akash-wallet-secret
+      key: passphrase
+  configuration:
+    keyName: "default"
+    keyringBackend: "test"
+    net: "sandbox"
+    version: "v2.0.0"
+    chainId: "sandbox-2"
+    accountAddress: "akash1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    node: "https://rpc.example.akash.network:443"
+    home: "/tmp/.akash"
+    path: "/usr/local/bin/akash"
+    providersApi: "https://akash-api.example.com"
+    skipTLSVerification: true
+```
+
+### SDL
+
+Declares the workload — container images, exposed ports, compute resources, placement attributes, and pricing — using Akash's Stack Definition Language.
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: SDL
+metadata:
+  name: example-sdl
+spec:
+  providerConfigRef:
+    name: akash-provider
+  forProvider:
+    version: "2.0"
+    services:
+      web:
+        image: nginx:1.21.6
+        expose:
+          - port: 80
+            as: 80
+            to:
+              - global: true
+    profiles:
+      compute:
+        web:
+          resources:
+            cpu: "0.5"
+            memory: "512Mi"
+            storage:
+              - size: "1Gi"
+      placement:
+        westcoast:
+          attributes:
+            region: us-west
+          pricing:
+            web:
+              amount: 100
+    deployment:
+      web:
+        profile: westcoast
+        count: 1
+```
+
+### Deployment
+
+Creates the on-chain deployment from the referenced SDL, locks the deposit, and writes connection details to the named secret once a lease is active.
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: Deployment
+metadata:
+  name: example-deployment
+  labels:
+    app: web-server
+    tier: frontend
+spec:
+  providerConfigRef:
+    name: akash-provider
+  forProvider:
+    sdlRef:
+      name: example-sdl
+    deposit: 4500000
+  writeConnectionSecretToRef:
+    name: example-deployment-connection
+    namespace: default
+```
+
+### BidPolicy
+
+Decides how incoming provider bids are evaluated — filters by attributes, caps the price, and (when `autoAccept` is true) opens a Lease automatically against the matching deployment.
+
+```yaml
+apiVersion: akash.overlock.network/v1alpha1
+kind: BidPolicy
+metadata:
+  name: example-bidpolicy
+spec:
+  providerConfigRef:
+    name: akash-provider
+  forProvider:
+    selector:
+      matchLabels:
+        app: web-server
+        tier: frontend
+    maxPrice: 500
+    excludedProviders:
+      - "akash1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    requiredAttributes:
+      - key: "region"
+        value: "us-west"
+    selectionStrategy: "lowest-price"
+    autoAccept: true
+    maxBids: 15
+```
+
+> Certificate and Manifest CRs are created automatically by the Lease controller once a lease becomes Active — you don't need to author them yourself.
 
 ## Examples
 
-Check out the `examples/` directory for more sample configurations and usage scenarios.
+Check out the [examples](examples/) directory for more sample configurations and usage scenarios.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Expand README **Usage** with per-resource subsections (Wallet Secret, ProviderConfig, SDL, Deployment, BidPolicy), each with a short description and an obfuscated manifest sourced from the local sandbox example.
- Drop the generic Create/Update/Delete bullets and link `examples/` and "Akash Network".
- Replace `OWNERS.md` upstream Crossplane maintainers with Overlock Network maintainership (Evgheni Poleacov).

## Test plan
- [ ] Render README on GitHub and confirm subsections, code blocks, and links display correctly.
- [ ] Confirm `examples/` link resolves on the PR.