### PR TITLE
40: create GitHub release with autogenerated notes on tag push

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - dependencies
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug fixes
+      labels:
+        - bug
+        - fix
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that fires on `v*` tag pushes, creates a GitHub Release named after the tag, and lets GitHub auto-generate the body from PRs/commits since the previous tag (`generate_release_notes: true`). Tags containing `-` (e.g. `v0.1.0-rc1`) are flagged as prereleases.
- Add `.github/release.yml` config so the auto-generated notes are grouped into Breaking changes / Features / Bug fixes / Documentation / Other, and dependabot/`skip-changelog` PRs are excluded.
- Runs in parallel with the existing `publish.yml` (which publishes the xpkg) — both trigger on the same `v*` tag.

## Test plan
- [ ] Push a `v*` tag and confirm a release is created with grouped notes covering PRs since the last tag.
- [ ] Push a `v*-rc*` tag and confirm the release is marked as prerelease.