### PR TITLE
40: push single digest per tag to xpkg.upbound.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,9 @@ jobs:
       repository: provider-akash
       version: ${{ github.ref_name }}
       registry_org: overlock-network
+      mirror: false
     secrets:
       GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
-      XPKG_MIRROR_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
-      XPKG_MIRROR_TOKEN: ${{ secrets.XPKG_TOKEN }}
 
   append-marketplace-extensions:
     needs: publish-provider-package
@@ -35,6 +34,11 @@ jobs:
           mv up "$HOME/.local/bin/up"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: up version
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/login-action@v3
         with:
           registry: xpkg.upbound.io

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ go.mod.cachedir:
 EXTENSIONS_DIR ?= _output/extensions
 EXTENSIONS_ICON ?= assets/icon.svg
 EXTENSIONS_README ?= docs/marketplace.md
-EXTENSIONS_IMAGE ?= xpkg.upbound.io/overlock-network/$(PROJECT_NAME):$(VERSION)
+EXTENSIONS_SOURCE ?= ghcr.io/overlock-network/$(PROJECT_NAME):$(VERSION)
+EXTENSIONS_DESTINATION ?= xpkg.upbound.io/overlock-network/$(PROJECT_NAME):$(VERSION)
 
 package.extensions:
 	@echo "Assembling marketplace extensions tree at $(EXTENSIONS_DIR)"
@@ -127,8 +128,8 @@ package.extensions:
 	@cp $(EXTENSIONS_README) $(EXTENSIONS_DIR)/readme/readme.md
 
 publish.extensions: package.extensions
-	@echo "Appending marketplace extensions to $(EXTENSIONS_IMAGE)"
-	@up alpha xpkg append --extensions-root=$(EXTENSIONS_DIR) $(EXTENSIONS_IMAGE)
+	@echo "Appending marketplace extensions from $(EXTENSIONS_SOURCE) to $(EXTENSIONS_DESTINATION)"
+	@up alpha xpkg append --extensions-root=$(EXTENSIONS_DIR) --destination=$(EXTENSIONS_DESTINATION) $(EXTENSIONS_SOURCE)
 
 .PHONY: submodules fallthrough test-integration run dev dev-clean go.mod.cachedir package.extensions publish.extensions
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -13,7 +13,7 @@ Manage [Akash Network](https://akash.network) resources declaratively from Kuber
 ## Install
 
 ```bash
-crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.0.10
+crossplane xpkg install provider xpkg.upbound.io/overlock-network/provider-akash:v0.0.15
 ```
 
 Or as a manifest:
@@ -24,7 +24,7 @@ kind: Provider
 metadata:
   name: provider-akash
 spec:
-  package: xpkg.upbound.io/overlock-network/provider-akash:v0.0.10
+  package: xpkg.upbound.io/overlock-network/provider-akash:v0.0.15
 ```
 
 ## Prerequisites


### PR DESCRIPTION
Fixes marketplace listing freezing on v0.0.9. Each tag from v0.0.10 onward was pushed twice to `xpkg.upbound.io` with two different digests: once by the reusable workflow's mirror, then again by `up alpha xpkg append` rewriting the same tag. The marketplace ingestor latched onto the first digest and never re-keyed.

- Disable the reusable workflow's mirror (`mirror: false`) so it only publishes to ghcr.io.
- `make publish.extensions` now reads from `ghcr.io/...:VERSION` and writes to `xpkg.upbound.io/...:VERSION` via `--destination`, so the upbound registry sees exactly one push per tag with extensions baked in.
- Bump install snippets in `docs/marketplace.md` to v0.0.15.